### PR TITLE
Remove RMagick dependency (and improve performance, yay! 🎉)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem 'i18n'
 gem 'rqrcode'
-gem 'rmagick'
 
 group :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     rake (13.0.1)
-    rmagick (4.1.2)
     rqrcode (1.1.2)
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.1)
@@ -32,7 +31,6 @@ PLATFORMS
 DEPENDENCIES
   i18n
   rake
-  rmagick
   rqrcode
   rspec
 

--- a/README.md
+++ b/README.md
@@ -13,22 +13,6 @@ These checks are required to be perfomed by the running application.
 ```
 gem install qr-bills
 ```
-
-### Dependencies
-This gem depends on RMagick to add the Swiss cross to the QR code. 
-If you got some issues when installing RMagick (bundle install), you can add the following dependencies to your system:
-
-```
-# Debian, Ubuntu,...
-sudo apt-get install libmagickwand-dev imagemagick
-
-# CentOS, RHEL,...
-$ yum install ImageMagick-devel
-
-# MacOS
-$ brew install imagemagick
-```
-
 ### Locales / Translations
 To support translations, copy/paste the 4 languages code into your I18n engine: ```config/locales/*.yml```
 

--- a/lib/qr-bills/qr-generator.rb
+++ b/lib/qr-bills/qr-generator.rb
@@ -1,6 +1,4 @@
 require 'rqrcode'
-require 'rmagick'
-include Magick
 
 class QRGenerator
   # payload:
@@ -40,7 +38,6 @@ class QRGenerator
  
   def self.create(params, qrcode_path)
     create_qr(params, qrcode_path)
-    add_swiss_cross(qrcode_path, qrcode_path)
   end
 
   def self.create_qr(params, qrcode_path)
@@ -93,13 +90,8 @@ class QRGenerator
       size: 1024,
     )
 
-    IO.binwrite(qrcode_path, png.to_s)
-  end
-
-  def self.add_swiss_cross(qrcode_path, final_path)
-    qr_image    = Image.read(qrcode_path)[0]
-    swiss_cross = Image.read(File.expand_path("#{File.dirname(__FILE__)}/../../web/assets/images/swiss_cross.png"))[0]
-    final_qr    = qr_image.composite(swiss_cross, CenterGravity, OverCompositeOp)
-    final_qr.write(final_path)
+    swiss_cross = ChunkyPNG::Image.from_file(File.expand_path("#{File.dirname(__FILE__)}/../../web/assets/images/swiss_cross.png"))
+    final_qr    = png.compose!(swiss_cross, 10, 10)
+    final_qr.save(qrcode_path)
   end
 end

--- a/lib/qr-bills/qr-generator.rb
+++ b/lib/qr-bills/qr-generator.rb
@@ -37,10 +37,6 @@ class QRGenerator
   #  "eBill/B/41010560425610173";                 # alternative scheme paramaters, max 100 chars
  
   def self.create(params, qrcode_path)
-    create_qr(params, qrcode_path)
-  end
-
-  def self.create_qr(params, qrcode_path)
     payload = "SPC\r\n"
     payload += "0200\r\n"
     payload += "1\r\n"
@@ -91,7 +87,7 @@ class QRGenerator
     )
 
     swiss_cross = ChunkyPNG::Image.from_file(File.expand_path("#{File.dirname(__FILE__)}/../../web/assets/images/swiss_cross.png"))
-    final_qr    = png.compose!(swiss_cross, 10, 10)
+    final_qr    = png.compose!(swiss_cross, (png.width - swiss_cross.width) / 2,  (png.height - swiss_cross.height) / 2)
     final_qr.save(qrcode_path)
   end
 end

--- a/qr-bills.gemspec
+++ b/qr-bills.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.7.1"
   s.add_runtime_dependency("i18n", ">= 1.8.3", "< 2")
   s.add_runtime_dependency("rqrcode", ">= 1.1.2", "< 2")
-  s.add_runtime_dependency("rmagick", ">= 4.1.2", "< 5")
   s.add_development_dependency("rspec", "~> 3.9")
   s.add_development_dependency("rake", "~> 13.0")
 end

--- a/spec/qr-generator_spec.rb
+++ b/spec/qr-generator_spec.rb
@@ -42,9 +42,5 @@ RSpec.describe "QRGenerator" do
     it "generates successfully a qr image" do
       expect{QRGenerator.create_qr(@params, @filepath)}.not_to raise_error
     end
-
-    it "add successfully the swiss cross on the qr code" do
-      expect{QRGenerator.add_swiss_cross(@filepath, @filepath)}.not_to raise_error
-    end
   end
 end

--- a/spec/qr-generator_spec.rb
+++ b/spec/qr-generator_spec.rb
@@ -1,46 +1,45 @@
 require 'qr-bills'
 require 'fileutils'
 require 'qr-bills/qr-generator'
-require 'RMagick'
-include Magick
 
-RSpec.configure do |config|
-  config.before(:each) do
-    @params = QRParams.get_qr_params
-    @params[:bill_params][:creditor][:iban] = "CH9300762011623852957"
-    @params[:bill_params][:creditor][:address][:type] = "S"
-    @params[:bill_params][:creditor][:address][:name] = "Compagnia di assicurazione forma & scalciante"
-    @params[:bill_params][:creditor][:address][:line1] = "Via cantonale"
-    @params[:bill_params][:creditor][:address][:line2] = "24"
-    @params[:bill_params][:creditor][:address][:postal_code] = "3000"
-    @params[:bill_params][:creditor][:address][:town] = "Lugano"
-    @params[:bill_params][:creditor][:address][:country] = "CH"
-    @params[:bill_params][:amount] = 12345.15
-    @params[:bill_params][:currency] = "CHF"
-    @params[:bill_params][:debtor][:address][:type] = "S"
-    @params[:bill_params][:debtor][:address][:name] = "Foobar Barfoot"
-    @params[:bill_params][:debtor][:address][:line1] = "Via cantonale"
-    @params[:bill_params][:debtor][:address][:line2] = "25"
-    @params[:bill_params][:debtor][:address][:postal_code] = "3001"
-    @params[:bill_params][:debtor][:address][:town] = "Comano"
-    @params[:bill_params][:debtor][:address][:country] = "CH"
-    @params[:bill_params][:reference] = "RF89MTR81UUWZYO48NY55NP3"
-    @params[:bill_params][:reference_type] = "SCOR"
-    @params[:bill_params][:additionally_information] = "pagamento riparazione monopattino"
+RSpec.describe QRGenerator do
 
-    @path = "#{Dir.pwd}/tmp/"
-    @filepath = @path + "qrcode.png"
-  end
-
-  config.before(:all) do
+  before do
     FileUtils.mkdir_p "#{Dir.pwd}/tmp/"
+    File.delete filepath if File.exist?(filepath)
   end
-end
 
-RSpec.describe "QRGenerator" do
+  let(:filepath) { "#{Dir.pwd}/tmp/qrcode.png" }
+  let(:params) do
+    QRParams.get_qr_params.tap do |params_hash|
+      params_hash[:bill_params][:creditor][:iban] = "CH9300762011623852957"
+      params_hash[:bill_params][:creditor][:address][:type] = "S"
+      params_hash[:bill_params][:creditor][:address][:name] = "Compagnia di assicurazione forma & scalciante"
+      params_hash[:bill_params][:creditor][:address][:line1] = "Via cantonale"
+      params_hash[:bill_params][:creditor][:address][:line2] = "24"
+      params_hash[:bill_params][:creditor][:address][:postal_code] = "3000"
+      params_hash[:bill_params][:creditor][:address][:town] = "Lugano"
+      params_hash[:bill_params][:creditor][:address][:country] = "CH"
+      params_hash[:bill_params][:amount] = 12345.15
+      params_hash[:bill_params][:currency] = "CHF"
+      params_hash[:bill_params][:debtor][:address][:type] = "S"
+      params_hash[:bill_params][:debtor][:address][:name] = "Foobar Barfoot"
+      params_hash[:bill_params][:debtor][:address][:line1] = "Via cantonale"
+      params_hash[:bill_params][:debtor][:address][:line2] = "25"
+      params_hash[:bill_params][:debtor][:address][:postal_code] = "3001"
+      params_hash[:bill_params][:debtor][:address][:town] = "Comano"
+      params_hash[:bill_params][:debtor][:address][:country] = "CH"
+      params_hash[:bill_params][:reference] = "RF89MTR81UUWZYO48NY55NP3"
+      params_hash[:bill_params][:reference_type] = "SCOR"
+      params_hash[:bill_params][:additionally_information] = "pagamento riparazione monopattino"
+    end
+  end
+
   describe "qrcode generation" do
     it "generates successfully a qr image" do
-      expect{QRGenerator.create_qr(@params, @filepath)}.not_to raise_error
+      expect(File.exist?(filepath)).to be_falsy
+      expect{QRGenerator.create(params, filepath)}.not_to raise_error
+      expect(File.exist?(filepath)).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Hi @damoiser,

this PR removes the need for RMagick.
Apart from that it is also faster as the current implementation (still unbearable slow though 😢).

![Benchmark screenshot](https://user-images.githubusercontent.com/372620/113192410-00eccf00-925f-11eb-83f6-bd206f68d3e3.png)

As you can see the implementation becomes even faster if [`oily_png`](https://github.com/wvanbergen/oily_png) is used.
This is an _optional_ mixin for Chunky PNG. This means it will speed up the implementation of the current PR.

I would have added a hint to the README _but_ the current implementation of oily_png is _not_ compatible yet with the current implementation of Chunky PNG (I did the benchmark with [this branch](https://github.com/wvanbergen/oily_png/pull/21)).

Thus this should/could be added later on.

This PR already is improving speed and removes an unnecessary dependency. So I guess this should be good for now. 😉 