### PR TITLE
chores: tiny refactoring

### DIFF
--- a/lib/qr-bills/qr-creditor-reference.rb
+++ b/lib/qr-bills/qr-creditor-reference.rb
@@ -1,7 +1,7 @@
 require 'qr-bills/qr-exceptions'
 
 # implement Creditor Reference ISO 11649 generator
-class QRCreditorReference
+module QRCreditorReference
   PREFIX = "RF"
 
   @char_values = {

--- a/lib/qr-bills/qr-exceptions.rb
+++ b/lib/qr-bills/qr-exceptions.rb
@@ -1,4 +1,4 @@
-class QRExceptions
+module QRExceptions
   EXCEPTION_PREFIX = "QR-bill"
 
   INVALID_PARAMETERS = EXCEPTION_PREFIX + " invalid parameters"

--- a/lib/qr-bills/qr-generator.rb
+++ b/lib/qr-bills/qr-generator.rb
@@ -1,6 +1,6 @@
 require 'rqrcode'
 
-class QRGenerator
+module QRGenerator
   # payload:
   #  "SPC\r\n" +    # indicator for swiss qr code: SPC (swiss payments code)
   #  "0200\r\n" +   # version of the specifications, 0200 = v2.0

--- a/lib/qr-bills/qr-html-layout.rb
+++ b/lib/qr-bills/qr-html-layout.rb
@@ -1,6 +1,6 @@
 require 'qr-bills/qr-generator'
 
-class QRHTMLLayout
+module QRHTMLLayout
 
   def self.create(params)
     QRGenerator.create(params, params[:qrcode_filepath])

--- a/lib/qr-bills/qr-params.rb
+++ b/lib/qr-bills/qr-params.rb
@@ -56,43 +56,38 @@ module QRParams
   end
 
   def self.valid?(params)
-    if params.has_key?(:bill_type)
+    return false unless params.key?(:bill_type)
+    return false unless QRParams.base_params_valid?(params)
 
-      if !QRParams.base_params_valid?(params)
-        return false
-      end
-
-      if params[:bill_type] == QR_BILL_WITH_QR_REFERENCE
-        return QRParams.qr_bill_with_qr_reference_valid?(params)
-      elsif params[:bill_type] == QR_BILL_WITH_CREDITOR_REFERENCE
-        return QRParams.qr_bill_with_creditor_reference_valid?(params)
-      elsif params[:bill_type] == QR_BILL_WITHOUT_REFERENCE
-        return QRParams.qr_bill_without_reference_valid?(params)
-      else
-        return false
-      end
+    case params[:bill_type]
+    when QRParams::QR_BILL_WITH_QR_REFERENCE
+      QRParams.qr_bill_with_qr_reference_valid?(params)
+    when QRParams::QR_BILL_WITH_CREDITOR_REFERENCE
+      QRParams.qr_bill_with_creditor_reference_valid?(params)
+    when QRParams::QR_BILL_WITHOUT_REFERENCE
+      QRParams.qr_bill_without_reference_valid?(params)
     else
-      return false
+      false
     end
   end
-
+  
   def self.base_params_valid?(params)
-    # todo
-    return true
+    # TODO
+    true
   end
 
   def self.qr_bill_with_qr_reference_valid?(params)
-    # todo
-    return true
+    # TODO
+    true
   end
 
   def self.qr_bill_with_creditor_reference_valid?(params)
-    # todo
-    return true
+    # TODO
+    true
   end
 
   def self.qr_bill_without_reference_valid?(params)
-    # todo
-    return true
+    # TODO
+    true
   end
 end

--- a/spec/qr-bills_spec.rb
+++ b/spec/qr-bills_spec.rb
@@ -3,11 +3,11 @@ require 'qr-bills'
 RSpec.describe QRBills do
   describe "init" do
     it "raise an exception if the bill kind is not set" do
-      expect{QRBills.generate({})}.to raise_error("QR-bill invalid parameters: bill type param not set")
+      expect { QRBills.generate({}) }.to raise_error(ArgumentError, "QR-bill invalid parameters: bill type param not set")
     end
-  
+
     it "raise an exception if the bill kind is not valid" do
-      expect{QRBills.generate({bill_type: "bad"})}.to raise_error("QR-bill invalid parameters: params validation check failed")
+      expect { QRBills.generate(bill_type: "bad") }.to raise_error(ArgumentError, "QR-bill invalid parameters: validation failed")
     end
   end
 end


### PR DESCRIPTION
This is a very tiny refactoring.
Also this removes setting `I18n.default_locale` (therefore this should fix #2). No gem should ever do that!
Please set locale defaults in your application instead and don't mess with user settings.

Also the Gem modules should be scoped within a proper namespace and you don't have to use instance variables in specs. Use `let` instead. And you don't need `RSpec.configure` in every spec file. Hooks like `before` are available within a `describe` block.
You can see [here an example](https://github.com/damoiser/qr-bills/pull/4/files#diff-9a4b3ecedfeccdf3c19fbcd87f2c2ccb26bab22c116ccc22f76f303466eb2855).
So I guess there are still enough things to do. 😉  But the gem is working, which is great. 👍 

Also you can ask me anytime in case you need feedback or some help.

Apart from the few refactoring things `png` is now supported as a direct output format. 😉 