### PR TITLE
Setup new CI with circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
+      - run: bundle install
       - run: bundle list
       - run: bundle exec rake spec
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  test:
+    docker:
+      - image: circleci/ruby:2.7.1-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run: bundle list
+      - run: bundle exec rake spec
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  test-pipeline:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: circleci/ruby:2.7.1-stretch-node
+      - image: cimg/ruby:2.7.4
     executor: ruby/default
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     docker:
       - image: cimg/ruby:2.7.4
     executor: ruby/default
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - run: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
     docker:
       - image: cimg/ruby:2.7.4
     executor: ruby/default
+    resource_class: small
     steps:
       - checkout
       - run: bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-cache: bundler
-
-rvm:
-  - 2.7.1
-
-script:
-  - bundle list
-  - bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * improve readme / documentation
 * fix typo in param: alternative_scheme_parameters
 
-### v0.3
+### v0.3
 * refactoring and fix typos
 * remove RMagick and use ChunkyPNG
 * add output format qrcode-png

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/damoiser/qr-bills.svg?branch=master)](https://travis-ci.com/damoiser/qr-bills)
+[![CircleCI](https://circleci.com/gh/damoiser/qr-bills/tree/master.svg?style=svg)](https://circleci.com/gh/damoiser/qr-bills/tree/master)
 ![](https://ruby-gem-downloads-badge.herokuapp.com/qr-bills?type=total)
 [![Gem Version](https://badge.fury.io/rb/qr-bills.svg)](https://badge.fury.io/rb/qr-bills)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate?business=DJNJMV5YAEBT6&currency_code=CHF)


### PR DESCRIPTION
Travis becomes not free anymore for open source projects, but CI are still important, then migration to another CI tool is required.

This PR closes #14
