### PR TITLE
fix: amount formatting and error correction code (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.idea
 *.gem
 tmp/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v1.0.5
+* fix amount formatting ('%.2f')
+* adjust qr error code to m as specs: see PR#18
+
 ### v1.0.4
 * remove rake dependency
 

--- a/lib/qr-bills/qr-generator.rb
+++ b/lib/qr-bills/qr-generator.rb
@@ -84,6 +84,7 @@ module QRGenerator
       resize_exactly_to: false,
       resize_gte_to: false,
       size: 1024,
+      level: 'm'
     )
 
     swiss_cross = ChunkyPNG::Image.from_file(File.expand_path("#{File.dirname(__FILE__)}/../../web/assets/images/swiss_cross.png"))

--- a/lib/qr-bills/qr-html-layout.rb
+++ b/lib/qr-bills/qr-html-layout.rb
@@ -44,7 +44,7 @@ module QRHTMLLayout
 
     layout += "      <div class=\"amount_value\">\n"
     layout += "        <span class=\"amount_header subtitle\">#{I18n.t("qrbills.amount").capitalize}</span><br/>\n"
-    layout += "        #{params[:bill_params][:amount]}<br/>\n"
+    layout += "        #{format('%.2f', params[:bill_params][:amount])}<br/>\n"
     layout += "      </div>\n"
     layout += "    </div>\n"
     
@@ -65,7 +65,7 @@ module QRHTMLLayout
     
     layout += "        <div class=\"amount_value\">\n"
     layout += "          <span class=\"amount_header subtitle\">#{I18n.t("qrbills.amount").capitalize}</span><br/>\n"
-    layout += "          #{params[:bill_params][:amount]}<br/>\n"
+    layout += "          #{format('%.2f',params[:bill_params][:amount])}<br/>\n"
     layout += "        </div>\n"
     layout += "      </div>\n"
     

--- a/qr-bills.gemspec
+++ b/qr-bills.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = "qr-bills"
-  s.version     = "1.0.4"
-  s.date        = "2021-11-04"
+  s.version     = "1.0.5"
+  s.date        = "2022-02-03"
   s.summary     = "QR-bills support for swiss payments"
   s.description = "QR-bills support for swiss payments, for full documentation please refer to github repo: https://github.com/damoiser/qr-bills"
   s.authors     = ["Damiano Radice"]

--- a/spec/qr-html-layout_spec.rb
+++ b/spec/qr-html-layout_spec.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
     @params[:bill_params][:creditor][:address][:postal_code] = "3000"
     @params[:bill_params][:creditor][:address][:town] = "Lugano"
     @params[:bill_params][:creditor][:address][:country] = "CH"
-    @params[:bill_params][:amount] = 12345.1
+    @params[:bill_params][:amount] = 12345.15
     @params[:bill_params][:currency] = "CHF"
     @params[:bill_params][:debtor][:address][:type] = "S"
     @params[:bill_params][:debtor][:address][:name] = "Foobar Barfoot"
@@ -59,6 +59,43 @@ RSpec.describe "QRHTMLLayout" do
       # just test that is not empty
       expect(File.size("#{Dir.pwd}/tmp/html-layout.html")).to be > 10
       expect(File.size("#{Dir.pwd}/tmp/qrcode-html.png")).to be > 10
+    end
+
+    it "rounds correctly (1)" do
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      IO.binwrite("#{Dir.pwd}/tmp/html-layout.html", html_output)
+      expect(File.exist?("#{Dir.pwd}/tmp/html-layout.html")).to be_truthy
+      expect(File.exist?("#{Dir.pwd}/tmp/qrcode-html.png")).to be_truthy
+
+      # just test that is not empty
+      expect(html_output).to include("12345.15")
+    end
+
+    it "rounds correctly (2)" do
+      @params[:bill_params][:amount] = 12345.1
+
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      IO.binwrite("#{Dir.pwd}/tmp/html-layout.html", html_output)
+      expect(File.exist?("#{Dir.pwd}/tmp/html-layout.html")).to be_truthy
+      expect(File.exist?("#{Dir.pwd}/tmp/qrcode-html.png")).to be_truthy
+
+      # just test that is not empty
+      expect(html_output).to include("12345.10")
+    end
+
+    it "rounds correctly (1)" do
+      @params[:bill_params][:amount] = 12345.10
+
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      IO.binwrite("#{Dir.pwd}/tmp/html-layout.html", html_output)
+      expect(File.exist?("#{Dir.pwd}/tmp/html-layout.html")).to be_truthy
+      expect(File.exist?("#{Dir.pwd}/tmp/qrcode-html.png")).to be_truthy
+
+      # just test that is not empty
+      expect(html_output).to include("12345.10")
     end
   end
 end

--- a/spec/qr-html-layout_spec.rb
+++ b/spec/qr-html-layout_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe "QRHTMLLayout" do
       expect(File.exist?("#{Dir.pwd}/tmp/html-layout.html")).to be_truthy
       expect(File.exist?("#{Dir.pwd}/tmp/qrcode-html.png")).to be_truthy
 
-      # just test that is not empty
       expect(html_output).to include("12345.15")
     end
 
@@ -81,7 +80,6 @@ RSpec.describe "QRHTMLLayout" do
       expect(File.exist?("#{Dir.pwd}/tmp/html-layout.html")).to be_truthy
       expect(File.exist?("#{Dir.pwd}/tmp/qrcode-html.png")).to be_truthy
 
-      # just test that is not empty
       expect(html_output).to include("12345.10")
     end
 
@@ -94,7 +92,6 @@ RSpec.describe "QRHTMLLayout" do
       expect(File.exist?("#{Dir.pwd}/tmp/html-layout.html")).to be_truthy
       expect(File.exist?("#{Dir.pwd}/tmp/qrcode-html.png")).to be_truthy
 
-      # just test that is not empty
       expect(html_output).to include("12345.10")
     end
   end

--- a/spec/qr-html-layout_spec.rb
+++ b/spec/qr-html-layout_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "QRHTMLLayout" do
       expect(html_output).to include("12345.10")
     end
 
-    it "rounds correctly (1)" do
+    it "rounds correctly (3)" do
       @params[:bill_params][:amount] = 12345.10
 
       html_output = QRHTMLLayout.create(@params).to_s

--- a/spec/qr-html-layout_spec.rb
+++ b/spec/qr-html-layout_spec.rb
@@ -1,4 +1,6 @@
+require 'i18n'
 require 'qr-bills/qr-html-layout'
+require 'qr-bills/qr-params'
 
 RSpec.configure do |config|
   config.before(:each) do
@@ -17,7 +19,7 @@ RSpec.configure do |config|
     @params[:bill_params][:creditor][:address][:postal_code] = "3000"
     @params[:bill_params][:creditor][:address][:town] = "Lugano"
     @params[:bill_params][:creditor][:address][:country] = "CH"
-    @params[:bill_params][:amount] = 12345.15
+    @params[:bill_params][:amount] = 12345.1
     @params[:bill_params][:currency] = "CHF"
     @params[:bill_params][:debtor][:address][:type] = "S"
     @params[:bill_params][:debtor][:address][:name] = "Foobar Barfoot"


### PR DESCRIPTION
- [x] Apply `'%.2f'` formatting to amounts in html
- [x] Set QR error correction code to M as per spec 
- [x] Adjust test
- [x] Add RubyMine project folder to git ignore