### PR TITLE
Use I18n.locale as default language instead of "it"

### DIFF
--- a/lib/qr-bills/qr-params.rb
+++ b/lib/qr-bills/qr-params.rb
@@ -17,7 +17,7 @@ module QRParams
         path: File.expand_path("#{File.dirname(__FILE__)}/../../config/locales")
       },
       bill_params: {
-        language: "it",
+        language: I18n.locale,
         amount: 0.0,
         currency: "CHF",
         reference_type: "", # QRR = QR reference, SCOR = Creditor reference, NON = without reference

--- a/spec/qr-params_spec.rb
+++ b/spec/qr-params_spec.rb
@@ -1,7 +1,10 @@
+require 'i18n'
 require 'qr-bills/qr-params'
 
 RSpec.configure do |config|
   config.before(:each) do
+    I18n.default_locale = :it
+
     @params = QRParams.get_qr_params
     @params[:bill_type] = QRParams::QR_BILL_WITH_QR_REFERENCE
     @params[:fonts][:eot] = "../web/assets/fonts/LiberationSans-Regular.eot"
@@ -35,6 +38,10 @@ end
 
 
 RSpec.describe "QR params" do
+  it "uses current locale as language" do
+    expect(@params[:bill_params][:language]).to be :it
+  end
+
   describe "basic param validation" do
     it "fails if bill type is empty" do
       @params[:bill_type] = ""


### PR DESCRIPTION
The gem has "it" hardcoded for `params[:bill_params][:language]` when generating a new qr params hash.

Not a big issue, but this PR switches from the hardcoded `"it"` to the dynamic `I18n.locale`. This way one can rely on the current I18n.locale (e.g. in a request cycle) instead of having to add an extra line to adjust the language.