### PR TITLE
Support QR bills without a predefined amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### Unreleased
+* Support QR-bills without a predefined amount (`params[:bill_params][:amount] = nil`), per
+  section 4.2.2 of the Swiss Implementation Guidelines for the QR-bill: `Amt` is optional,
+  the payer/banking app fills it in after scanning. The `Amt` payload line stays present but
+  empty, `Ccy` is unaffected. The `html` output now renders the regulatory empty field with
+  corner registration marks (40x15mm on the payment part, 30x10mm on the receipt) instead of
+  a numeric value. A present amount must still be between 0.01 and 999999999.99 (now
+  validated - previously unchecked). Amount-present behavior is unchanged.
+
 ### v2.0.0
 * fix optional fields validation warnings for StrdBkgInf and AltPmt
 * Not backward compatible! 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ bill = QRBills.generate(params)
 
 ```
 
+### QR-bill without a predefined amount
+
+Per section 4.2.2 of the Swiss Implementation Guidelines for the QR-bill, `Amt` is optional:
+pass `nil` (instead of a number) to generate a QR-bill where the payer (or their banking app,
+after scanning) fills in the amount themselves - useful e.g. for an early-payment discount,
+where the final amount depends on when the invoice gets paid.
+
+```ruby
+params[:bill_params][:amount] = nil
+```
+
+Everything else (IBAN, addresses, reference, currency) works exactly the same. The `html`
+output renders the regulatory empty field with corner registration marks instead of a
+number; `png`/`svg` just encode the QR code payload with an empty (but present) `Amt` line.
+If you do set an amount, it must be between 0.01 and 999'999'999.99.
+
 ## References
 * https://www.paymentstandards.ch/dam/downloads/ig-qr-bill-en.pdf
 * https://www.paymentstandards.ch/en/shared/know-how/faq/qr.html
@@ -145,8 +161,6 @@ bill = QRBills.generate(params)
 ## TODO
 
 * add other outputs formats
-* add "empty" QR-Bill
-![QR bill empty](./imgs/qr_bill_empty.png)
 
 ## License
 

--- a/lib/qr-bills/qr-generator.rb
+++ b/lib/qr-bills/qr-generator.rb
@@ -137,7 +137,10 @@ module QRGenerator
     payload += "\r\n"
     payload += "\r\n"
     payload += "\r\n"
-    payload += "#{format('%.2f', bill_params[:amount])}\r\n"
+    # Amt (section 4.2.2 of the Swiss Implementation Guidelines for the QR-bill) is optional:
+    # a nil amount means the payer fills it in themselves (e.g. an early-payment discount),
+    # but the line must stay present (empty) since Ccy always immediately follows it.
+    payload += "#{bill_params[:amount].nil? ? '' : format('%.2f', bill_params[:amount])}\r\n"
     payload += "#{bill_params[:currency]}\r\n"
     payload += "#{bill_params[:debtor][:address][:type]}\r\n"
     payload += "#{bill_params[:debtor][:address][:name]}\r\n"

--- a/lib/qr-bills/qr-html-layout.rb
+++ b/lib/qr-bills/qr-html-layout.rb
@@ -58,7 +58,7 @@ module QRHTMLLayout
 
       layout += "      <div class=\"amount_value\">\n"
       layout += "        <span class=\"amount_header subtitle\">#{I18n.t("qrbills.amount").capitalize}</span><br/>\n"
-      layout += "        #{format('%.2f', params[:bill_params][:amount])}<br/>\n"
+      layout +=          render_amount_value(params[:bill_params][:amount], "receipt_amount_blank")
       layout += "      </div>\n"
       layout += "    </div>\n"
 
@@ -79,7 +79,7 @@ module QRHTMLLayout
 
       layout += "        <div class=\"amount_value\">\n"
       layout += "          <span class=\"amount_header subtitle\">#{I18n.t("qrbills.amount").capitalize}</span><br/>\n"
-      layout += "          #{format('%.2f',params[:bill_params][:amount])}<br/>\n"
+      layout +=          render_amount_value(params[:bill_params][:amount], "payment_amount_blank")
       layout += "        </div>\n"
       layout += "      </div>\n"
 
@@ -202,6 +202,53 @@ module QRHTMLLayout
       layout += "    margin-right: 15px;\n"
       layout += "  }\n"
 
+      # Empty amount field with corner registration marks (Swiss Implementation Guidelines
+      # 3.5.3 payment part / 3.6.3 receipt): 4 small L-shaped strokes, 0.75pt, at each corner
+      # of the box the payer (or their banking app) is expected to fill in by hand.
+      layout += "  .amount_blank {\n"
+      layout += "    position: relative;\n"
+      layout += "  }\n"
+
+      layout += "  .receipt_amount_blank {\n"
+      layout += "    width: 30mm;\n"
+      layout += "    height: 10mm;\n"
+      layout += "  }\n"
+
+      layout += "  .payment_amount_blank {\n"
+      layout += "    width: 40mm;\n"
+      layout += "    height: 15mm;\n"
+      layout += "  }\n"
+
+      layout += "  .amount_blank .corner {\n"
+      layout += "    position: absolute;\n"
+      layout += "    width: 3mm;\n"
+      layout += "    height: 3mm;\n"
+      layout += "  }\n"
+
+      layout += "  .amount_blank .corner_tl {\n"
+      layout += "    top: 0; left: 0;\n"
+      layout += "    border-top: 0.75pt solid #000;\n"
+      layout += "    border-left: 0.75pt solid #000;\n"
+      layout += "  }\n"
+
+      layout += "  .amount_blank .corner_tr {\n"
+      layout += "    top: 0; right: 0;\n"
+      layout += "    border-top: 0.75pt solid #000;\n"
+      layout += "    border-right: 0.75pt solid #000;\n"
+      layout += "  }\n"
+
+      layout += "  .amount_blank .corner_bl {\n"
+      layout += "    bottom: 0; left: 0;\n"
+      layout += "    border-bottom: 0.75pt solid #000;\n"
+      layout += "    border-left: 0.75pt solid #000;\n"
+      layout += "  }\n"
+
+      layout += "  .amount_blank .corner_br {\n"
+      layout += "    bottom: 0; right: 0;\n"
+      layout += "    border-bottom: 0.75pt solid #000;\n"
+      layout += "    border-right: 0.75pt solid #000;\n"
+      layout += "  }\n"
+
       layout += "  .title {\n"
       layout += "    font-weight: bold;\n"
       layout += "    font-size: 11pt;\n"
@@ -243,6 +290,22 @@ module QRHTMLLayout
 
       layout
     end
+  end
+
+  # When the amount is not predefined (params[:bill_params][:amount] is nil), the Swiss
+  # Implementation Guidelines (sections 3.5.3 / 3.6.3) require an empty field with corner
+  # registration marks instead of a printed value: 40x15mm on the payment part, 30x10mm on
+  # the receipt. The two call sites only differ in the box's CSS class (which sets the size).
+  def self.render_amount_value(amount, blank_css_class)
+    return "#{format('%.2f', amount)}<br/>\n" unless amount.nil?
+
+    layout  = "<div class=\"amount_blank #{blank_css_class}\">\n"
+    layout += "  <div class=\"corner corner_tl\"></div>\n"
+    layout += "  <div class=\"corner corner_tr\"></div>\n"
+    layout += "  <div class=\"corner corner_bl\"></div>\n"
+    layout += "  <div class=\"corner corner_br\"></div>\n"
+    layout += "</div>\n"
+    layout
   end
 
   def self.render_address(address)

--- a/lib/qr-bills/qr-params.rb
+++ b/lib/qr-bills/qr-params.rb
@@ -80,7 +80,24 @@ module QRParams
     if params.dig(:bill_params, :currency) == "" || params.dig(:bill_params, :currency) == nil
       raise ArgumentError, "#{QRExceptions::INVALID_PARAMETERS}: currency cannot be blank"
     end
- 
+
+    QRParams.amount_valid?(params)
+
+    true
+  end
+
+  # Amt (section 4.2.2 of the Swiss Implementation Guidelines for the QR-bill) is optional:
+  # nil means "no predefined amount" (the payer fills it in, e.g. for an early-payment
+  # discount) and is always valid. When present it must be a strictly positive amount
+  # within the range the spec allows.
+  def self.amount_valid?(params)
+    amount = params.dig(:bill_params, :amount)
+    return true if amount.nil?
+
+    unless amount.is_a?(Numeric) && amount >= 0.01 && amount <= 999_999_999.99
+      raise ArgumentError, "#{QRExceptions::INVALID_PARAMETERS}: amount must be nil (no predefined amount) or between 0.01 and 999999999.99"
+    end
+
     true
   end
 

--- a/spec/qr-generator_spec.rb
+++ b/spec/qr-generator_spec.rb
@@ -87,11 +87,104 @@ RSpec.describe QRGenerator do
     it "optional fields are correctly generated as txt payload (and to test against SIX validator) > bill_information_coded & alternative_scheme_parameters" do
       params[:bill_params][:alternative_scheme_parameters] = "eBill/B/41010560425610173"
       params[:bill_params][:bill_information_coded] = "//S1/10/10201409/11/181105/40/0:30"
-      
+
       txt = QRGenerator.build_payload(params[:bill_params])
       File.write('tmp/qrcode_information_coded_and_alt_scheme.txt', txt)
       file = File.open('spec/fixtures/qrcode_information_coded_and_alt_scheme.txt').read
       expect(txt).to eq(file)
+    end
+  end
+
+  describe "optional amount (Amt, section 4.2.2 of the Swiss Implementation Guidelines)" do
+    def lines(txt)
+      txt.split("\r\n", -1)
+    end
+
+    it "keeps the classic amount-present payload byte-identical to before this change" do
+      txt = QRGenerator.build_payload(params[:bill_params])
+      file = File.open('spec/fixtures/qrcode.txt').read
+      expect(txt).to eq(file)
+    end
+
+    it "encodes an empty (but present) Amt line when amount is nil, Ccy immediately following" do
+      params[:bill_params][:amount] = nil
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      # Amt is at index 18, Ccy at index 19 - fixed positions per the payload layout
+      # regardless of whether an amount is present.
+      expect(payload_lines[18]).to eq("")
+      expect(payload_lines[19]).to eq("CHF")
+    end
+
+    it "encodes an empty Amt line when the amount key is omitted entirely" do
+      params[:bill_params].delete(:amount)
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      expect(payload_lines[18]).to eq("")
+      expect(payload_lines[19]).to eq("CHF")
+    end
+
+    it "does not shift any other field when amount is nil (creditor/debtor/reference intact)" do
+      params[:bill_params][:amount] = nil
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      expect(payload_lines[3]).to eq("CH9300762011623852957") # creditor IBAN
+      expect(payload_lines[20]).to eq("S") # debtor address type
+      expect(payload_lines[21]).to eq("Foobar Barfoot") # debtor name
+      expect(payload_lines[27]).to eq("SCOR") # reference type
+      expect(payload_lines[28]).to eq("RF89MTR81UUWZYO48NY55NP3") # reference
+    end
+
+    it "supports EUR with no predefined amount" do
+      params[:bill_params][:amount] = nil
+      params[:bill_params][:currency] = "EUR"
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      expect(payload_lines[18]).to eq("")
+      expect(payload_lines[19]).to eq("EUR")
+    end
+
+    it "keeps formatting a real amount with 2 decimals as before" do
+      params[:bill_params][:amount] = 42
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      expect(payload_lines[18]).to eq("42.00")
+    end
+
+    it "still works with a QRR reference and no predefined amount" do
+      params[:bill_params][:amount] = nil
+      params[:bill_params][:reference_type] = "QRR"
+      params[:bill_params][:reference] = "210000000003139471430009017"
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      expect(payload_lines[18]).to eq("")
+      expect(payload_lines[27]).to eq("QRR")
+      expect(payload_lines[28]).to eq("210000000003139471430009017")
+    end
+
+    it "still works with a NON reference (no reference) and no predefined amount" do
+      params[:bill_params][:amount] = nil
+      params[:bill_params][:reference_type] = "NON"
+      params[:bill_params][:reference] = ""
+
+      txt = QRGenerator.build_payload(params[:bill_params])
+      payload_lines = lines(txt)
+
+      expect(payload_lines[18]).to eq("")
+      expect(payload_lines[27]).to eq("NON")
+      expect(payload_lines[28]).to eq("")
     end
   end
 end

--- a/spec/qr-html-layout_spec.rb
+++ b/spec/qr-html-layout_spec.rb
@@ -124,4 +124,50 @@ RSpec.describe "QRHTMLLayout" do
       expect(html_output).to include("12345.10")
     end
   end
+
+  describe "optional amount (no predefined amount)" do
+    before do
+      @params[:qrcode_format] = 'png'
+      @params[:bill_params][:amount] = nil
+    end
+
+    it "does not raise and does not print a numeric amount" do
+      html_output = nil
+      expect { html_output = QRHTMLLayout.create(@params).to_s }.not_to raise_error
+      expect(html_output).not_to include("<br/>0.00")
+    end
+
+    it "renders a 40x15mm empty field with corner marks in the payment section" do
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      expect(html_output).to include("payment_amount_blank")
+      expect(html_output).to include("width: 40mm")
+      expect(html_output).to include("height: 15mm")
+    end
+
+    it "renders a 30x10mm empty field with corner marks in the receipt section" do
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      expect(html_output).to include("receipt_amount_blank")
+      expect(html_output).to include("width: 30mm")
+      expect(html_output).to include("height: 10mm")
+    end
+
+    it "draws the 4 corner registration marks at 0.75pt" do
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      expect(html_output).to include("corner_tl")
+      expect(html_output).to include("corner_tr")
+      expect(html_output).to include("corner_bl")
+      expect(html_output).to include("corner_br")
+      expect(html_output).to include("0.75pt solid #000")
+    end
+
+    it "still shows currency and amount labels" do
+      html_output = QRHTMLLayout.create(@params).to_s
+
+      expect(html_output).to include(I18n.t("qrbills.currency").capitalize)
+      expect(html_output).to include(I18n.t("qrbills.amount").capitalize)
+    end
+  end
 end

--- a/spec/qr-params_spec.rb
+++ b/spec/qr-params_spec.rb
@@ -68,6 +68,59 @@ RSpec.describe "QR params" do
     end
   end
 
+  describe "optional amount validation" do
+    it "is valid when amount is nil (no predefined amount)" do
+      @params[:bill_params][:amount] = nil
+      expect{QRParams.amount_valid?(@params)}.not_to raise_error
+      expect(QRParams.amount_valid?(@params)).to be_truthy
+    end
+
+    it "is valid when the amount key is entirely absent" do
+      @params[:bill_params].delete(:amount)
+      expect{QRParams.amount_valid?(@params)}.not_to raise_error
+    end
+
+    it "is valid with a classic decimal amount" do
+      @params[:bill_params][:amount] = 12345.15
+      expect{QRParams.amount_valid?(@params)}.not_to raise_error
+    end
+
+    it "is valid at the lower bound (0.01)" do
+      @params[:bill_params][:amount] = 0.01
+      expect{QRParams.amount_valid?(@params)}.not_to raise_error
+    end
+
+    it "is valid at the upper bound (999999999.99)" do
+      @params[:bill_params][:amount] = 999_999_999.99
+      expect{QRParams.amount_valid?(@params)}.not_to raise_error
+    end
+
+    it "rejects a zero amount" do
+      @params[:bill_params][:amount] = 0
+      expect{QRParams.amount_valid?(@params)}.to raise_error(ArgumentError, /amount must be nil.*or between 0.01 and 999999999.99/)
+    end
+
+    it "rejects a zero float amount" do
+      @params[:bill_params][:amount] = 0.0
+      expect{QRParams.amount_valid?(@params)}.to raise_error(ArgumentError, /amount must be nil.*or between 0.01 and 999999999.99/)
+    end
+
+    it "rejects a negative amount" do
+      @params[:bill_params][:amount] = -5.0
+      expect{QRParams.amount_valid?(@params)}.to raise_error(ArgumentError, /amount must be nil.*or between 0.01 and 999999999.99/)
+    end
+
+    it "rejects an amount above the maximum" do
+      @params[:bill_params][:amount] = 1_000_000_000.00
+      expect{QRParams.amount_valid?(@params)}.to raise_error(ArgumentError, /amount must be nil.*or between 0.01 and 999999999.99/)
+    end
+
+    it "is enforced through base_params_valid? too" do
+      @params[:bill_params][:amount] = -1
+      expect{QRParams.base_params_valid?(@params)}.to raise_error(ArgumentError, /amount must be nil.*or between 0.01 and 999999999.99/)
+    end
+  end
+
   describe "qr bill with QR reference params validation" do
     it "fails if reference is not QRR" do
       @params[:bill_params][:reference_type]= "bla"


### PR DESCRIPTION
## Summary

Adds support for QR-bills without a predefined amount (`params[:bill_params][:amount] = nil`).

Per **section 4.2.2** of the [Swiss Implementation Guidelines for the QR-bill, version 2.3](https://www.six-group.com/dam/download/banking-services/standardization/qr-bill/ig-qr-bill-v2.3-en.pdf) (SIX Interbank Clearing / Swiss Payment Standards), `Amt` is optional. When omitted, the payer (or their banking app, after scanning the QR code) fills in the amount themselves. A concrete use case: an invoice offering an early-payment discount, where the exact amount due depends on when the payer pays.

Sections **3.5.3** (payment part layout) and **3.6.3** (receipt layout) require that, when the amount is not predefined, an *empty field with corner registration marks* (0.75pt) be printed instead of a value: **40×15mm** on the payment part, **30×10mm** on the receipt.

## Problem today

`qr-generator.rb#build_payload` and `qr-html-layout.rb` both unconditionally call `format("%.2f", amount)`. There's no way to encode a QR-bill without a predefined amount without either passing `0.0` (which is a real, incorrect value - not "no amount") or monkey-patching the gem.

## What changed

- **`lib/qr-bills/qr-params.rb`**
  - Added `QRParams.amount_valid?`, wired into `base_params_valid?`: `nil` is always valid (no predefined amount); a present amount must be a `Numeric` in `[0.01, 999999999.99]` (previously **no validation existed at all** for amount - zero, negative, and absurdly large values were silently accepted).
  - Kept the existing default `amount: 0.0` in `get_qr_params` unchanged, so callers who don't touch `amount` keep getting today's `"0.00"` behavior - only an explicit `nil` (or deleting the key) opts into the no-amount behavior. This avoids any silent output change for existing callers.

- **`lib/qr-bills/qr-generator.rb#build_payload`**
  - The `Amt` line is now an empty (but present) line when `bill_params[:amount]` is `nil`. `Ccy`, which always immediately follows `Amt` in the SPC payload, is unaffected and unshifted - it's a positional field, not a trailing one. No other field shifts position. QRR/SCOR/NON references are unrelated and keep working unchanged (regression coverage added).
  - A present amount still formats with 2 decimals exactly as before.

- **`lib/qr-bills/qr-html-layout.rb`**
  - Extracted a `render_amount_value(amount, blank_css_class)` helper used at both existing call sites (receipt + payment section). When `amount` is `nil` it renders an empty box with 4 corner registration marks (0.75pt, absolutely-positioned bordered `div`s, matching the gem's existing hand-built HTML+CSS string style) instead of a numeric value - 30×10mm (`receipt_amount_blank`) on the receipt, 40×15mm (`payment_amount_blank`) on the payment part. Currency/amount labels are still shown. All other layout (A6 dimensions, spacing, fonts) is untouched.

## Non-regression

The pre-existing `spec/fixtures/qrcode.txt` fixture (and the other fixture-based specs) still match **byte-for-byte** with amount present - verified by running the full existing spec suite unchanged, plus a dedicated new spec asserting the fixture payload is unchanged. I don't have a way to scan a real QR-bill with a banking app as part of this change (no such environment available) - the non-regression check above, plus manual line-by-line inspection of the raw SPC payload string (diffing an amount-present vs. no-amount payload), is what backs this PR; see the "What I verified" note in the PR discussion if useful.

## Tests added

- `spec/qr-generator_spec.rb`: nil amount / omitted amount key → empty `Amt` line with `Ccy` immediately following; no field shift (creditor/debtor/reference all intact); CHF and EUR; a real amount still formats with 2 decimals; QRR and NON reference types both still work with no predefined amount; byte-for-byte non-regression against the existing fixture.
- `spec/qr-params_spec.rb`: nil/omitted amount valid; boundary values (0.01, 999999999.99) valid; zero (int and float), negative, and above-max amounts rejected with a clear `ArgumentError`; enforced through `base_params_valid?`.
- `spec/qr-html-layout_spec.rb`: no exception and no numeric amount printed when nil; 40×15mm zone with corner marks in the payment section; 30×10mm zone with corner marks in the receipt section; 0.75pt corner marks present; currency/amount labels still shown.

Covers all three output formats: `svg`/`png` (via the shared payload builder) and `html` (layout + CSS).

Full existing suite (43 examples) plus all new specs (23) pass: **66 examples, 0 failures**.

## Related

Issue #33 ("Add empty fields") is a stalled, code-less preliminary sketch of exactly this empty-field layout requirement (screenshot only, no linked branch/PR). This PR is independent prior art addressing the same underlying spec requirement, not a duplicate.

## What I did not verify

- No real banking-app scan of the generated QR code (I don't have that capability here) - non-regression is proven by byte-for-byte payload comparison against the pre-existing fixture, not a live scan.
- No visual/manual proofread of the rendered HTML in an actual browser/PDF renderer - the corner-mark CSS follows the same inline-style technique already used elsewhere in this file, but I'd appreciate a maintainer's visual sanity check before merge.
